### PR TITLE
add SECCS.asmdef.meta

### DIFF
--- a/SECCS/SECCS.asmdef.meta
+++ b/SECCS/SECCS.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eacb7d59886d5bf44a41da246fe41390
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
a .meta file is required to give the assembly a consistent GUID that can be referenced by other assemblies.